### PR TITLE
Contribution banner

### DIFF
--- a/tiddlers/Contribution Banner Stylesheet.css
+++ b/tiddlers/Contribution Banner Stylesheet.css
@@ -1,0 +1,17 @@
+@media (min-width: 960px)
+<style>…</style>
+.tc-improvement-banner {
+    margin-right: -53px;
+    margin-left: -53px;
+}
+
+.tc-improvement-banner {
+    font-size: 1.3em;
+    background: #fcc;
+    padding-left: 5px;
+    margin-top: 6px;
+    margin-bottom: 12px;
+    -webkit-box-shadow: 2px 2px 2px rgba(0,0,0,0.4);
+    -moz-box-shadow: 2px 2px 2px rgba(0,0,0,0.4);
+    box-shadow: 2px 2px 2px rgba(0,0,0,0.4);
+}

--- a/tiddlers/Contribution Banner Stylesheet.css.meta
+++ b/tiddlers/Contribution Banner Stylesheet.css.meta
@@ -1,0 +1,4 @@
+tags: $:/tags/Stylesheet
+title: Contribution Banner Stylesheet
+tmap.id: 74f7a96f-d090-4199-8d13-85ddb66ee1b5
+type: text/css

--- a/tiddlers/ContributionBanner.tid
+++ b/tiddlers/ContributionBanner.tid
@@ -1,0 +1,21 @@
+list-after: $:/core/ui/EditTemplate/title
+tags: $:/tags/EditTemplate
+title: $:/ContributionBanner
+type: text/vnd.tiddlywiki
+
+\define makeGitHubLink()
+https://github.com/zefram-cochrane/Zefram-Cochrane.github.io/edit/master/tiddlers/$(githubLink)$
+\end
+\define innerMakeGitHubLink(linkText)
+<$set name="githubLink" value={{$:/config/OriginalTiddlerPaths##$(draftOfTiddler)$}}>
+<a href=<<makeGitHubLink>> class="tc-tiddlylink-external" target="_blank" rel="noopener noreferrer">$linkText$</a>
+</$set>
+\end
+\define outerMakeGitHubLink(linkText)
+<$set name="draftOfTiddler" value={{$(currentTiddler)$!!draft.of}}>
+<<innerMakeGitHubLink "$linkText$">>
+</$set>
+\end
+<div class="tc-improvement-banner">
+{{$:/core/images/star-filled}} Can you help us improve this documentation? <<outerMakeGitHubLink "Edit this tiddler on GitHub">> or [[get help on editing the wiki|Editing the Wiki]].
+</div>

--- a/tiddlers/ContributionBanner.tid
+++ b/tiddlers/ContributionBanner.tid
@@ -17,5 +17,5 @@ https://github.com/zefram-cochrane/Zefram-Cochrane.github.io/edit/master/tiddler
 </$set>
 \end
 <div class="tc-improvement-banner">
-{{$:/core/images/star-filled}} Can you help us improve this documentation? <<outerMakeGitHubLink "Edit this tiddler on GitHub">> or [[get help on editing the wiki|Editing the Wiki]].
+Do you want to share your changes with others? You can <<outerMakeGitHubLink "edit this tiddler on GitHub directly">>, or [[find more help on editing the wiki|Editing the Wiki]]. Sharing is caring!
 </div>

--- a/tiddlywiki.info
+++ b/tiddlywiki.info
@@ -8,5 +8,8 @@
     "themes": [
         "tiddlywiki/vanilla",
         "tiddlywiki/snowwhite"
-    ]
+    ],
+    "config": {
+        "retain-original-tiddler-path": true
+    }
 }


### PR DESCRIPTION
This adds a contribution banner.
When contributors hit the edit button of a tiddler, they are presented a banner guiding them on how to share their contributions with others. The banner links to the "edit this wiki" page as well as the edit page of the tiddler on github.

![image](https://user-images.githubusercontent.com/285398/50547912-ecff3080-0c43-11e9-9eff-05c7be8a1d49.png)

Based on [TiddlyWiki's contribtion banner].

  [TiddlyWiki's contribtion banner]: https://tiddlywiki.com/#How%20to%20add%20a%20banner%20for%20GitHub%20contributions